### PR TITLE
Update alert paths

### DIFF
--- a/bosh/infrastructure-staging.yml
+++ b/bosh/infrastructure-staging.yml
@@ -5,8 +5,8 @@ networks:
   - range: (( grab terraform_outputs.staging_monitoring_subnet_cidr ))
     gateway: (( grab terraform_outputs.staging_monitoring_subnet_gateway ))
     dns:
-    - (( grab terraform_outputs.staging_monitoring_subnet_dns ))
     - (( grab terraform_outputs.tooling_bosh_static_ip ))
+    - (( grab terraform_outputs.vpc_cidr_dns ))
     cloud_properties:
       subnet: (( grab terraform_outputs.staging_monitoring_subnet ))
       security_groups:

--- a/bosh/jobs.yml
+++ b/bosh/jobs.yml
@@ -41,10 +41,10 @@ jobs:
   properties:
     prometheus:
       rule_files:
-      - /var/vcap/packages/bosh_alerts/*.alerts
-      - /var/vcap/packages/cloudfoundry_alerts/*.alerts
-      - /var/vcap/packages/kubernetes_alerts/*.alerts
-      - /var/vcap/packages/prometheus_alerts/*.alerts
+      - /var/vcap/jobs/bosh_alerts/*.alerts
+      - /var/vcap/jobs/cloudfoundry_alerts/*.alerts
+      - /var/vcap/jobs/kubernetes_alerts/*.alerts
+      - /var/vcap/jobs/prometheus_alerts/*.alerts
       scrape_configs:
       - job_name: prometheus
         static_configs:
@@ -112,11 +112,11 @@ jobs:
           enabled: true
       prometheus:
         dashboard_files:
-        - /var/vcap/packages/bosh_dashboards/*.json
-        - /var/vcap/packages/system_dashboards/*.json
-        - /var/vcap/packages/cloudfoundry_dashboards/*.json
-        - /var/vcap/packages/kubernetes_dashboards/*.json
-        - /var/vcap/packages/prometheus_dashboards/*.json
+        - /var/vcap/jobs/bosh_dashboards/*.json
+        - /var/vcap/jobs/system_dashboards/*.json
+        - /var/vcap/jobs/cloudfoundry_dashboards/*.json
+        - /var/vcap/jobs/kubernetes_dashboards/*.json
+        - /var/vcap/jobs/prometheus_dashboards/*.json
 
 - name: nginx
   templates:


### PR DESCRIPTION
This release uses bosh links and needs bosh dns for vms to locate each other. WDYT is the right order of dns servers @LinuxBozo @cnelson ?