### PR TITLE
Add influxdb exporter.

### DIFF
--- a/bosh/jobs.yml
+++ b/bosh/jobs.yml
@@ -58,6 +58,10 @@ instance_groups:
           static_configs:
           - targets:
             - localhost:9188
+        - job_name: influxdb_exporter
+          static_configs:
+          - targets:
+            - localhost:9122
         - job_name: node
           file_sd_configs:
           - files:
@@ -90,6 +94,8 @@ instance_groups:
         metrics:
           environment: (( grab meta.environment ))
   - name: kube_state_metrics_exporter
+    release: prometheus
+  - name: influxdb_exporter
     release: prometheus
   - name: bosh_alerts
     release: prometheus


### PR DESCRIPTION
So that we can collect concourse metrics. See https://github.com/cloudfoundry-community/prometheus-boshrelease/pull/82 and https://github.com/cloudfoundry-community/prometheus-boshrelease/pull/90.