### PR TITLE
[WIP] Monitor push gateway jobs

### DIFF
--- a/bosh/alerts/bosh_unknown_instance.alerts
+++ b/bosh/alerts/bosh_unknown_instance.alerts
@@ -1,12 +1,12 @@
 ALERT BoshUnknownInstanceCheckExpired
-  IF time() - push_time_seconds{job="boshunknowninstance-lastcheck"} > 7200
+  IF time() - push_time_seconds{job="bosh_unknown_instance"} > 3600
   LABELS {
     service = "bosh_unknown_iaas_instance",
     severity = "critical",
   }
   ANNOTATIONS {
-    summary = "Bosh Unknown Instance Check for VPC {{$labels.instance}} has not run in two hours",
-    description = "Check bosh director {{$labels.instance}} for errors",
+    summary = "Bosh Unknown Instance Check for VPC {{$labels.vpc_name}} has not run for one hour",
+    description = "Check bosh director {{$labels.vpc_name}} for errors",
   }
 
 ALERT BoshUnknownInstanceExpired

--- a/bosh/alerts/bosh_unknown_instance.alerts
+++ b/bosh/alerts/bosh_unknown_instance.alerts
@@ -9,6 +9,18 @@ ALERT BoshUnknownInstanceCheckExpired
     description = "Check bosh director {{$labels.vpc_name}} for errors",
   }
 
+ALERT BoshUnknownInstanceCheckAbsent
+  IF absent(push_time_seconds{job="bosh_unknown_instance"}) == 1
+  FOR 1h
+  LABELS {
+    service = "bosh_unknown_iaas_instance",
+    severity = "critical",
+  }
+  ANNOTATIONS {
+    summary = "Bosh Unknown Instance Check for VPC {{$labels.vpc_name}} has not run for one hour",
+    description = "Check bosh director {{$labels.vpc_name}} for errors",
+  }
+
 ALERT BoshUnknownInstanceExpired
   IF bosh_unknown_iaas_instance > 0
   LABELS {


### PR DESCRIPTION
Based on https://github.com/prometheus/pushgateway#about-timestamps we should probably be monitoring the `push_time_seconds` created by the push gateway for each job, instead of a timestamp generated elsewhere.