### PR TITLE
[WIP] Add check and alert for aws mfa status.

### DIFF
--- a/bosh/alerts/aws_iam_mfa.alerts
+++ b/bosh/alerts/aws_iam_mfa.alerts
@@ -1,0 +1,21 @@
+ALERT AWSMFADisabled
+  IF aws_iam_user_mfa != 1
+  LABELS {
+    service = "aws_iam",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "AWS IAM user {{$labels.instance}} does not have MFA enabled",
+    description = "Remind user {{$labels.instance}} to enable MFA",
+  }
+
+ALERT AWSMFANotRunning
+  IF time() - aws_iam_user_lastcheck > 7200
+  LABELS {
+    service = "aws_iam",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "AWS IAM check is not running",
+    description = "Check https://ci.fr.cloud.gov/teams/main/pipelines/deploy-prometheus?groups=checks for failures",
+  }

--- a/bosh/jobs.yml
+++ b/bosh/jobs.yml
@@ -48,6 +48,7 @@ instance_groups:
         - (( file "bosh/alerts/kubernetes_broker.alerts" ))
         - (( file "bosh/alerts/logsearch_backup.alerts" ))
         - (( file "bosh/alerts/awslogs.alerts" ))
+        - (( file "bosh/alerts/aws_iam_mfa.alerts" ))
         - (( file "bosh/alerts/bosh_unknown_instance.alerts" ))
         scrape_configs:
         - job_name: prometheus

--- a/ci/aws-mfa.sh
+++ b/ci/aws-mfa.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eux
+
+users=$(aws iam list-users | jq -r '.Users[] | select (.PasswordLastUsed) | .UserName')
+mfas=$(aws iam list-virtual-mfa-devices | jq -r '.VirtualMFADevices[] | .User.UserName')
+
+tempfile=$(mktemp)
+
+for user in ${users}; do
+  has_mfa=0
+  if echo "${user}" | grep -Fw "${mfas}"; then
+    has_mfa=1
+  fi
+  echo "aws_iam_user_mfa{instance=\"${user}\"} ${has_mfa}" >> "${tempfile}"
+done
+
+curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
+curl --data-binary @${tempfile} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
+echo "aws_iam_user_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam/instance/lastcheck"
+
+rm -f "${tempfile}"

--- a/ci/aws-mfa.yml
+++ b/ci/aws-mfa.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+- {name: prometheus-config}
+
+run:
+  path: prometheus-config/ci/aws-mfa.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,6 +7,7 @@ groups:
 - name: checks
   jobs:
   - awslogs-check
+  - aws-mfa-check
 
 jobs:
 - name: awslogs-check
@@ -33,6 +34,21 @@ jobs:
         :flashing-alert: Instances should be stopped due to failure to log, but that's commented out pending SCR approval!
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       text_file: stopping/instance-id
+
+- name: aws-mfa-check
+  serial_groups: [production]
+  plan:
+  - aggregate:
+    - get: aws-mfa-timer
+      trigger: true
+    - get: prometheus-config
+      resource: prometheus-config
+  - task: aws-mfa
+    file: prometheus-config/ci/aws-mfa.yml
+    tags: [iaas]
+    params:
+      AWS_DEFAULT_REGION: {{aws-region}}
+      GATEWAY_HOST: {{gateway-host}}
 
 - name: deploy-prometheus-staging
   serial: true
@@ -263,6 +279,11 @@ resources:
     region_name: {{aws-region}}
 
 - name: awslogs-timer
+  type: time
+  source:
+    interval: 30m
+
+- name: aws-mfa-timer
   type: time
   source:
     interval: 30m


### PR DESCRIPTION
So that we don't have to check aws iam users for mfa manually. We'll need to verify this once production prometheus exists again before merging.