### PR TITLE
[WIP] Run elastic exporter on elastic vms.

### DIFF
--- a/bosh/jobs.yml
+++ b/bosh/jobs.yml
@@ -80,9 +80,17 @@ instance_groups:
           - targets:
             - localhost:9122
         - job_name: elasticsearch_exporter
-          static_configs:
-          - targets:
-            - localhost:9114
+          file_sd_configs:
+          - files:
+            - /var/vcap/store/bosh_exporter/bosh_target_groups.json
+          relabel_configs:
+          - source_labels: [__meta_bosh_job_process_name]
+            regex: elasticsearch_exporter
+            action: keep
+          - source_labels: [__address__]
+            regex: "(.*)"
+            target_label: __address__
+            replacement: "${1}:9114"
         - job_name: node
           file_sd_configs:
           - files:
@@ -118,12 +126,6 @@ instance_groups:
     release: prometheus
   - name: influxdb_exporter
     release: prometheus
-  - name: elasticsearch_exporter
-    release: prometheus
-    properties:
-      elasticsearch_exporter:
-        es:
-          all: true
   - name: bosh_alerts
     release: prometheus
     properties:


### PR DESCRIPTION
We have multiple elastic clusters, but because of bosh, we can only run one elastic exporter per vm. This is part of a series of patches that runs elastic exporters on the elastic vms rather than prometheus.