### PR TITLE
Use the internal DNS names for concourse

### DIFF
--- a/ci/concourse-has-auth.sh
+++ b/ci/concourse-has-auth.sh
@@ -4,7 +4,7 @@ set -eux
 
 tempfile=$(mktemp)
 
-CONCOURSE_URIS="ci.fr.cloud.gov ci.fr-stage.cloud.gov"
+CONCOURSE_URIS="0.web.production-concourse.concourse-production.toolingbosh 0.web.staging-concourse.concourse-staging.toolingbosh"
 for URI in ${CONCOURSE_URIS}
 do
   TEAMS=$(curl -s https://"$URI"/api/v1/teams | jq -r '.[].name')

--- a/ci/concourse-main-opslogin.sh
+++ b/ci/concourse-main-opslogin.sh
@@ -4,7 +4,7 @@ set -eux
 
 tempfile=$(mktemp)
 
-CONCOURSE_URIS="ci.fr.cloud.gov ci.fr-stage.cloud.gov"
+CONCOURSE_URIS="0.web.production-concourse.concourse-production.toolingbosh 0.web.staging-concourse.concourse-staging.toolingbosh"
 for URI in ${CONCOURSE_URIS}
 do
   AUTHURL=$(curl -sL https://"$URI"/api/v1/teams/main/auth/methods | jq -r '.[].auth_url' | grep oauth)

--- a/ci/concourse-teams.sh
+++ b/ci/concourse-teams.sh
@@ -5,7 +5,7 @@ set -eux
 tempfile1=$(mktemp)
 tempfile2=$(mktemp)
 
-CONCOURSE_URIS=(ci.fr.cloud.gov ci.fr-stage.cloud.gov)
+CONCOURSE_URIS=(0.web.production-concourse.concourse-production.toolingbosh 0.web.staging-concourse.concourse-staging.toolingbosh)
 TEAMS_WHITELIST=(main)
 
 for URI in "${CONCOURSE_URIS[@]}"


### PR DESCRIPTION
Due to security groups and network speed, let's not traverse out, and use internal DNS names as managed by BOSH