### PR TITLE
Drop legacy push

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -33,8 +33,8 @@
         service: aws-rds
         severity: warning
       annotations:
-        summary: AWS RDS {{$labels.instance_identifier}} has used 88% or greater disk space
-        description: Email the organization administrator for {{$labels.instance_identifier}} to inquire about provisioning a larger database.
+        summary: AWS RDS {{$labels.instance}} has used 88% or greater disk space
+        description: Email the organization administrator for {{$labels.instance}} to inquire about provisioning a larger database.
 
 # CloudWatch logs alerts
 - type: replace

--- a/ci/aws-mfa.sh
+++ b/ci/aws-mfa.sh
@@ -15,8 +15,7 @@ for user in ${users}; do
   echo "aws_iam_user_mfa{instance=\"${user}\"} ${has_mfa}" >> "${tempfile}"
 done
 
-curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
-curl --data-binary @${tempfile} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
+curl -X PUT --data-binary @${tempfile} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
 echo "aws_iam_user_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam/instance/lastcheck"
 
 rm -f "${tempfile}"

--- a/ci/aws-rds-storage/rds_disk_space.py
+++ b/ci/aws-rds-storage/rds_disk_space.py
@@ -43,9 +43,10 @@ def get_free_space(db_instance):
 def get_prometheus_metrics(db_to_storage):
     results = ""
     for db_instance in db_to_storage:
-        results += 'aws_rds_disk_allocated{instance_identifier="' + db_instance + '"} ' + str(db_to_storage[db_instance]) + '\n'
-        results += 'aws_rds_disk_free{instance_identifier="' + db_instance + '"} ' + str(get_free_space(db_instance)) + '\n'
+        results += 'aws_rds_disk_allocated{instance="' + db_instance + '"} ' + str(db_to_storage[db_instance]) + '\n'
+        results += 'aws_rds_disk_free{instance="' + db_instance + '"} ' + str(get_free_space(db_instance)) + '\n'
     return results
+
 
 if __name__ == "__main__":
     if not ("GATEWAY_HOST") in os.environ:
@@ -53,13 +54,11 @@ if __name__ == "__main__":
         sys.exit(1)
 
     output = get_prometheus_metrics(db_to_storage_map())
-    prometheus_url = os.getenv("GATEWAY_HOST") + ":" + os.getenv("GATEWAY_PORT", "9091") + "/metrics/jobs/aws_rds_storage_check"
-    res = requests.delete(url=prometheus_url)
-    res.raise_for_status()
+    prometheus_url = os.getenv("GATEWAY_HOST") + ":" + os.getenv("GATEWAY_PORT", "9091") + "/metrics/job/aws_rds_storage_check"
 
-    res = requests.post(url=prometheus_url,
-        data = output,
-        headers = {'Content-Type': 'application/octet-stream'})
+    res = requests.put(url=prometheus_url,
+        data=output,
+        headers={'Content-Type': 'application/octet-stream'})
     res.raise_for_status()
 
 

--- a/ci/awslogs.sh
+++ b/ci/awslogs.sh
@@ -52,8 +52,7 @@ EOF
 
 done
 
-curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group"
-curl --data-binary @${group_metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group"
+curl -X PUT --data-binary @${group_metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group"
 
 if [ $(($(date +"%s") - ${GLOBAL_LAST_UPDATE})) -gt ${ALERT_THRESHOLD} ]; then
   STATUS=1
@@ -62,8 +61,7 @@ else
 fi
 
 # report overall log status
-curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group/instance/_GLOBAL"
-cat <<EOF | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group/instance/_GLOBAL"
+cat <<EOF | curl -X PUT --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_group/instance/_GLOBAL"
 awslogs_loggroup_not_logging {group="_GLOBAL"} ${STATUS}
 EOF
 
@@ -107,8 +105,7 @@ EOF
 
 done
 
-curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_instance"
-curl --data-binary @${instance_metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_instance"
+curl -X PUT --data-binary @${instance_metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs_instance"
 
 echo "Finished instance check. Checked $(cat /tmp/active_instances | wc -l) instances."
 

--- a/ci/concourse-has-auth.sh
+++ b/ci/concourse-has-auth.sh
@@ -16,8 +16,7 @@ do
     echo "concourse_has_auth{team=\"${TEAM}\"} ${has_auth}" >> "${tempfile}"
   done
 
-  curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_auth/concourse_url/${URI}"
-  curl --data-binary "@${tempfile}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_auth/concourse_url/${URI}"
+  curl -X PUT --data-binary "@${tempfile}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_auth/concourse_url/${URI}"
 
   rm -f "${tempfile}"
 done

--- a/ci/concourse-main-opslogin.sh
+++ b/ci/concourse-main-opslogin.sh
@@ -17,8 +17,6 @@ do
   echo "concourse_has_opslogin{instance=\"${URI}\"} ${has_opslogin}" >> "${tempfile}"
 done
 
-curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin"
-curl --data-binary "@${tempfile}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin"
-echo "concourse_has_opslogin_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin/instance/lastcheck"
+curl -X PUT --data-binary "@${tempfile}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin" echo "concourse_has_opslogin_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin/instance/lastcheck"
 
 rm -f "${tempfile}"

--- a/ci/concourse-teams.sh
+++ b/ci/concourse-teams.sh
@@ -20,8 +20,7 @@ do
     fi
     echo "concourse_extra_team{team=\"${TEAM}\"} ${extra_team}" >> "${tempfile1}"
   done
-  curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_extra_teams/concourse_url/${URI}"
-  curl --data-binary "@${tempfile1}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_extra_teams/concourse_url/${URI}"
+  curl -X PUT --data-binary "@${tempfile1}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_extra_teams/concourse_url/${URI}"
 
   for TEAM in "${TEAMS_WHITELIST[@]}"
   do
@@ -31,8 +30,7 @@ do
     fi
     echo "concourse_expected_team_missing{team=\"${TEAM}\"} ${expected_team_missing}" >> "${tempfile2}"
   done
-  curl -X DELETE "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_expected_teams/concourse_url/${URI}"
-  curl --data-binary "@${tempfile2}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_expected_teams/concourse_url/${URI}"
+  curl -X PUT --data-binary "@${tempfile2}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_expected_teams/concourse_url/${URI}"
   rm -f "${tempfile1}"
   rm -f "${tempfile2}"
 done


### PR DESCRIPTION
* Use /metrics/job/:job route instead of legacy /metrics/jobs/:job
* Push metrics with PUT so that existing metrics are replaced, then drop unnecessary DELETEs

> PUT is used to push a group of metrics. All metrics with the grouping key specified in the URL are replaced by the metrics pushed with PUT.