### PR TITLE
Include bosh deployment name in concourse metrics.

### DIFF
--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -72,6 +72,10 @@
               regex: "(.*)"
               target_label: __address__
               replacement: "${1}:9110"
+            - source_labels: [__meta_bosh_deployment]
+              regex: "(.*)"
+              target_label: bosh_deployment
+              replacement: "$1"
           - job_name: node
             file_sd_configs:
             - files:


### PR DESCRIPTION
h/t @LinuxBozo 