### PR TITLE
Use built-in last check metric for unknown vms metrics.

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -82,7 +82,7 @@
     name: bosh-unknown-instances
     rules:
     - alert: BoshUnknownInstanceCheckExpired
-      expr: time() - push_time_seconds{job="boshunknowninstance-lastcheck"} > 7200
+      expr: time() - push_time_seconds{job="bosh_unknown_instance"} > 7200
       labels:
         service: bosh-unknown-iaas-instance
         severity: critical

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -298,6 +298,14 @@
       annotations:
         summary: Concourse team {{$labels.team}} is missing on {{$labels.concourse_url}}
         description: Check Concourse {{$labels.concourse_url}} configuration for missing team {{$labels.team}}
+    - alert: ConcourseCheckNotRunning
+      expr: time() - push_time_seconds{job=~"concourse_.*"} > 7200
+      labels:
+        service: concourse
+        severity: warning
+      annotations:
+        summary: Concourse check {{$labels.job}} is not running
+        description: Check https://ci.fr.cloud.gov/teams/main/pipelines/deploy-prometheus?groups=checks for failures
 
 # Domain broker alerts
 - type: replace

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -13,7 +13,7 @@
         summary: AWS IAM user {{$labels.instance}} does not have MFA enabled
         description: Remind user {{$labels.instance}} to enable MFA
     - alert: AWSMFANotRunning
-      expr: time() - aws_iam_user_lastcheck > 7200
+      expr: time() - push_time_seconds{job="aws_iam"} > 7200
       labels:
         service: aws-iam
         severity: warning
@@ -51,7 +51,7 @@
         summary: CloudWatch Logs group {{$labels.group}} is not receiving logs
         description: CloudWatch Logs group {{$labels.group}} has not received a log in the last hour
     - alert: AWSLogsCheckNotRunning
-      expr: time() - awslogs_lastcheck > 7200
+      expr: time() - push_time_seconds{job=~"^awslogs.*"} > 7200
       labels:
         service: aws-logs
         severity: critical
@@ -248,7 +248,7 @@
         summary: UAA Client {{$labels.instance}} is not expected for {{$labels.uaa_url}}
         description: UAA Client {{$labels.instance}} exists but is not expected for {{$labels.uaa_url}}
     - alert: UAAClientAuditNotRunning
-      expr: time() - uaa_client_audit_lastcheck > 7200
+      expr: time() - push_time_seconds{job="uaa_client_audit"} > 7200
       labels:
         service: uaa-client-audit
         severity: warning

--- a/ci/aws-mfa.sh
+++ b/ci/aws-mfa.sh
@@ -16,6 +16,5 @@ for user in ${users}; do
 done
 
 curl -X PUT --data-binary @${tempfile} "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam"
-echo "aws_iam_user_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/aws_iam/instance/lastcheck"
 
 rm -f "${tempfile}"

--- a/ci/awslogs.sh
+++ b/ci/awslogs.sh
@@ -109,8 +109,6 @@ curl -X PUT --data-binary @${instance_metrics} "${GATEWAY_HOST}:${GATEWAY_PORT:-
 
 echo "Finished instance check. Checked $(cat /tmp/active_instances | wc -l) instances."
 
-echo "awslogs_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/awslogs"
-
 # Ensure that slack notification resource detects text file
 touch stopping/instance-id
 

--- a/ci/concourse-has-auth.sh
+++ b/ci/concourse-has-auth.sh
@@ -20,5 +20,3 @@ do
 
   rm -f "${tempfile}"
 done
-
-echo "concourse_has_auth_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_auth/instance/lastcheck"

--- a/ci/concourse-main-opslogin.sh
+++ b/ci/concourse-main-opslogin.sh
@@ -17,6 +17,4 @@ do
   echo "concourse_has_opslogin{instance=\"${URI}\"} ${has_opslogin}" >> "${tempfile}"
 done
 
-curl -X PUT --data-binary "@${tempfile}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin" echo "concourse_has_opslogin_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_has_opslogin/instance/lastcheck"
-
 rm -f "${tempfile}"

--- a/ci/concourse-teams.sh
+++ b/ci/concourse-teams.sh
@@ -34,6 +34,3 @@ do
   rm -f "${tempfile1}"
   rm -f "${tempfile2}"
 done
-
-echo "concourse_extra_teams_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_extra_teams/instance/lastcheck"
-echo "concourse_expected_teams_lastcheck $(date +'%s')" | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/concourse_expected_teams/instance/lastcheck"

--- a/ci/prometheus-down.sh
+++ b/ci/prometheus-down.sh
@@ -20,10 +20,7 @@ set -u
 : ${PROMETHEUSHOST:="0.prometheus.production-monitoring.prometheus-production.toolingbosh"}
 : ${ALERTMANAGERHOST:="0.alertmanager.production-monitoring.prometheus-production.toolingbosh"}
 : ${QUERIES:="
-  concourse_has_opslogin_lastcheck
-  bosh_unknown_iaas_instance_lastcheck
-  bosh_last_scrape_timestamp
-  aws_iam_user_lastcheck
+  push_time_seconds
 "}
 
 TIME=$(date +%s)


### PR DESCRIPTION
Now that the push gateway automatically provides a last check metric for
each group, we don't need to alert on a custom last check metric.

Goes with https://github.com/18F/cg-deploy-bosh/pull/285.