### PR TITLE
fixed up prometheus checks to get specific data

### DIFF
--- a/ci/prometheus-down.sh
+++ b/ci/prometheus-down.sh
@@ -21,7 +21,6 @@ set -u
 : ${ALERTMANAGERHOST:="0.alertmanager.production-monitoring.prometheus-production.toolingbosh"}
 : ${QUERIES:="
   push_time_seconds%7Bjob%3D\"concourse_has_auth\"%7D
-  push_time_seconds%7Bjob%3D\"boshunknowninstance-lastcheck\"%7D
   push_time_seconds%7Bjob%3D\"bosh_unknown_instance\",vpc_name=\"production\"%7D
   push_time_seconds%7Bjob%3D\"aws_iam\"%7D
 "}

--- a/ci/prometheus-down.sh
+++ b/ci/prometheus-down.sh
@@ -20,7 +20,10 @@ set -u
 : ${PROMETHEUSHOST:="0.prometheus.production-monitoring.prometheus-production.toolingbosh"}
 : ${ALERTMANAGERHOST:="0.alertmanager.production-monitoring.prometheus-production.toolingbosh"}
 : ${QUERIES:="
-  push_time_seconds
+  push_time_seconds%7Bjob%3D\"concourse_has_auth\"%7D
+  push_time_seconds%7Bjob%3D\"boshunknowninstance-lastcheck\"%7D
+  push_time_seconds%7Bjob%3D\"bosh_unknown_instance\",vpc_name=\"production\"%7D
+  push_time_seconds%7Bjob%3D\"aws_iam\"%7D
 "}
 
 TIME=$(date +%s)
@@ -45,11 +48,11 @@ for QUERY in ${QUERIES} ; do
       # make sure that the data is not too old (indicates that prometheus is not accepting data)
       TIMEDIFF=$((TIME - QTIME))
 
-      if [ "${TIMEDIFF}" -lt 600 ] ; then
-        echo "  data for ${QUERY} is less than 600s old"
+      if [ "${TIMEDIFF}" -lt 1900 ] ; then
+        echo "  data for ${QUERY} is less than 1900s old"
         UPDATEOK=yes
       else
-        echo "  data for ${QUERY} is greater than 600s old!"
+        echo "  data for ${QUERY} is greater than 1900s old! (${TIMEDIFF} seconds greater)"
       fi
     fi
   fi

--- a/ci/prometheus-down.sh
+++ b/ci/prometheus-down.sh
@@ -47,11 +47,11 @@ for QUERY in ${QUERIES} ; do
       # make sure that the data is not too old (indicates that prometheus is not accepting data)
       TIMEDIFF=$((TIME - QTIME))
 
-      if [ "${TIMEDIFF}" -lt 1900 ] ; then
-        echo "  data for ${QUERY} is less than 1900s old"
+      if [ "${TIMEDIFF}" -lt 2400 ] ; then
+        echo "  data for ${QUERY} is less than 2400s old"
         UPDATEOK=yes
       else
-        echo "  data for ${QUERY} is greater than 1900s old! (${TIMEDIFF} seconds greater)"
+        echo "  data for ${QUERY} is greater than 2400s old! (${TIMEDIFF} seconds greater)"
       fi
     fi
   fi


### PR DESCRIPTION
The switch to using push_time_seconds broke the prometheus downtime check, so I changed it to query the specific datapoints that we were querying before.