### PR TITLE
Refer to stemcell by os rather than name.

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -6,7 +6,7 @@ releases:
 
 stemcells:
 - alias: default
-  name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+  os: ubuntu-trusty
   version: latest
 
 update:


### PR DESCRIPTION
So that the upstream bosh dns runtime config applies to this vm;
apparently bosh runtime config include/exclude rules rely on labels and
not stemcell metadata.