### PR TITLE
Remove awslogs_check

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,7 +6,6 @@ groups:
   - deploy-prometheus-production
 - name: checks
   jobs:
-  - awslogs-check
   - aws-mfa-check
   - aws-rds-storage-check
   - domain-broker-certs
@@ -15,31 +14,6 @@ groups:
   - prometheus-down-check-production
 
 jobs:
-- name: awslogs-check
-  serial_groups: [production]
-  plan:
-  - aggregate:
-    - get: prometheus-check-timer
-      trigger: true
-    - get: prometheus-config
-      resource: prometheus-config
-  - task: awslogs
-    file: prometheus-config/ci/awslogs.yml
-    tags: [iaas]
-    params:
-      AWS_DEFAULT_REGION: ((aws-region))
-      GATEWAY_HOST: prometheus-production.service.cf.internal
-      HEARTBEAT_GROUP: /var/log/syslog
-  - put: slack
-    params:
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-      text: |
-        :flashing-alert: Instances should be stopped due to failure to log, but that's commented out pending SCR approval!
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      text_file: stopping/instance-id
-
 - name: aws-rds-storage-check
   serial_groups: [production]
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       HEARTBEAT_GROUP: /var/log/syslog
   - put: slack
     params:
-      channel: ((slack-channel))
+      channel: ((slack-news-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
       text: |

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -30,15 +30,6 @@ jobs:
       AWS_DEFAULT_REGION: ((aws-region))
       GATEWAY_HOST: prometheus-production.service.cf.internal
       HEARTBEAT_GROUP: /var/log/syslog
-  - put: slack
-    params:
-      channel: ((slack-news-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-      text: |
-        :flashing-alert: Instances should be stopped due to failure to log, but that's commented out pending SCR approval!
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      text_file: stopping/instance-id
 
 - name: aws-rds-storage-check
   serial_groups: [production]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,7 @@ groups:
   - deploy-prometheus-production
 - name: checks
   jobs:
+  - awslogs-check
   - aws-mfa-check
   - aws-rds-storage-check
   - domain-broker-certs
@@ -14,6 +15,31 @@ groups:
   - prometheus-down-check-production
 
 jobs:
+- name: awslogs-check
+  serial_groups: [production]
+  plan:
+  - aggregate:
+    - get: prometheus-check-timer
+      trigger: true
+    - get: prometheus-config
+      resource: prometheus-config
+  - task: awslogs
+    file: prometheus-config/ci/awslogs.yml
+    tags: [iaas]
+    params:
+      AWS_DEFAULT_REGION: ((aws-region))
+      GATEWAY_HOST: prometheus-production.service.cf.internal
+      HEARTBEAT_GROUP: /var/log/syslog
+  - put: slack
+    params:
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+      text: |
+        :flashing-alert: Instances should be stopped due to failure to log, but that's commented out pending SCR approval!
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      text_file: stopping/instance-id
+
 - name: aws-rds-storage-check
   serial_groups: [production]
   plan:


### PR DESCRIPTION
We have this check happening in PagerDuty already, so we don't need it in Slack too! :grin:

https://gsa-tts.slack.com/archives/C0ENP71UG/p1537808226000100