### PR TITLE
Don't set headers twice

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -334,6 +334,9 @@ instance_groups:
       cookie_secret: ((oauth-proxy-cookie-secret))
       oidc_issuer_url: https://opslogin.fr.cloud.gov/oauth/token
       email_domain: gsa.gov
+      # these are both set in nginx via *security-headers, and setting them twice breaks them
+      browser_xss_filter: False
+      content_type_nosniff: False
 variables:
 - name: grafana-admin-password
   type: password


### PR DESCRIPTION
We're setting X-XSS-Protection and X-Content-Type-Options in both nginx and oauth2_proxy - apparently with both of these headers, having them set twice breaks them. This removes them from the oauth2_proxy config and leaves them in the nginx config.