### PR TITLE
set org_name for grafana

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -259,6 +259,7 @@ instance_groups:
           anonymous:
             enabled: true
             org_role: Admin
+            org_name: cloud.gov
           basic:
             enabled: false
         dashboards:


### PR DESCRIPTION
In production, the main grafana org is called `cloud.gov`, which makes sense. In staging it's called `Main Org.` which is the default from grafana. This PR makes the org for anonymous users `cloud.gov` - after applying this change to staging, we'll need to rename the main org to `cloud.gov`, or people will get a login screen.