### PR TITLE
Enable cf_export job in prometheus - NO MERGE

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -113,6 +113,8 @@ instance_groups:
           - targets:
             - localhost:9190
         - job_name: cf
+          scrape_interval: 1m
+          scrape_timeout: 1m
           static_configs:
           - targets:
             - localhost:9193

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -112,6 +112,10 @@ instance_groups:
           static_configs:
           - targets:
             - localhost:9190
+        - job_name: cf
+          static_configs:
+          - targets:
+            - localhost:9193
         - job_name: firehose
           static_configs:
           - targets:

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -179,6 +179,16 @@ instance_groups:
             client_secret: ((bosh-client-secret))
         metrics:
           environment: ((environment))
+  - name: cf_exporter
+    release: prometheus
+    properties:
+      cf_exporter:
+        cf:
+          api_url: https://api.((domain))
+          client_id: ((cf-exporter-client-id))
+          client_secret: ((cf-exporter-client-secret))
+        metrics:
+          environment: ((environment))
   - name: firehose_exporter
     release: prometheus
     properties:

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -187,6 +187,7 @@ instance_groups:
           api_url: https://api.((domain))
           client_id: ((cf-exporter-client-id))
           client_secret: ((cf-exporter-client-secret))
+          deployment_name: cf-((environment))
         metrics:
           environment: ((environment))
   - name: firehose_exporter


### PR DESCRIPTION
This adds the cf_export job, which should start pulling cf stats into prometheus.

Relies on 18F/cg-deploy-cf#412