### PR TITLE
Switch header responsibility to oauth2-proxy

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -330,8 +330,6 @@ instance_groups:
           server_name: prometheus.((domain))
           headers: &security-headers
             X-Frame-Options: DENY
-            X-Content-Type-Options: nosniff
-            X-XSS-Protection: "1; mode=block"
             Strict-Transport-Security: "max-age=31536000; preload"
         alertmanager:
           http_port: 8081
@@ -352,9 +350,6 @@ instance_groups:
       cookie_secret: ((oauth-proxy-cookie-secret))
       oidc_issuer_url: https://opslogin.fr.cloud.gov/oauth/token
       email_domain: gsa.gov
-      # these are both set in nginx via *security-headers, and setting them twice breaks them
-      browser_xss_filter: False
-      content_type_nosniff: False
 variables:
 - name: grafana-admin-password
   type: password

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -350,6 +350,8 @@ instance_groups:
       cookie_secret: ((oauth-proxy-cookie-secret))
       oidc_issuer_url: https://opslogin.fr.cloud.gov/oauth/token
       email_domain: gsa.gov
+      browser_xss_filter: True
+      content_type_nosniff: True
 variables:
 - name: grafana-admin-password
   type: password


### PR DESCRIPTION
oauth2-proxy serves some pages for us, bypassing nginx, so when we removed the doubled-up headers by turning them off on oauth2, we caused them to not get set in some instances.