### PR TITLE
fix cron to fix email for good

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -41,12 +41,12 @@ instance_groups:
               echo "((smtp-certificate))" > ${OUTDIR}/server.crt
               update-ca-certificates
               monit restart alertmanager
-            minute: '*/30'
-            hour: '*'
-            day: '*'
-            month: '*'
-            wday: '*'
-            user: root
+          minute: '*/30'
+          hour: '*'
+          day: '*'
+          month: '*'
+          wday: '*'
+          user: root
   - name: alertmanager
     release: prometheus
     properties:


### PR DESCRIPTION
This should, really, finally, fix the non-running cronjob, which should mean that email notifications from prometheus should start working again without manual intervention.

The problem I found was that time and user properties are keys of each cron.entry, not cron.entry.script