### PR TITLE
added alert to separate operator stuff from customer stuff.

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -334,3 +334,23 @@
       annotations:
         summary: 'Tripwire found violations for {{$labels.instance}}, with action {{$labels.action}} in section {{$labels.section}}'
         description: Review Tripwire report in CloudWatch logs
+
+# CF Core - non-customer stuff.
+- alert: CFOperatorAppUnhealthy
+  expr: min(cf_application_instances{state=~"STARTED", organization_id="4175a5b2-78a4-42b0-94c2-280f8be41e7f"} - cf_application_instances_running{state=~"STARTED"}) by(environment, deployment, organization_name, space_name, application_name) > 0
+  for: <%= p('cloudfoundry_alerts.app_unhealthy.evaluation_time') %>
+  labels:
+    service: <%= p('cloudfoundry_alerts.app_service_name') %>
+    severity: warning
+  annotations:
+    summary: "CF Application `{{$labels.environment}}/{{$labels.deployment}}/{{$labels.organization_name}}/{{$labels.space_name}}/{{$labels.application_name}}` is unhealthy"
+    description: "CF Application `{{$labels.application_name}}` at environment `{{$labels.environment}}`, deployment `{{$labels.deployment}}`, org `{{$labels.organization_name}}`, and space `{{$labels.space_name}}` had less instances running than desired during the last <%= p('cloudfoundry_alerts.app_unhealthy.evaluation_time') %>"
+- alert: CFOperatorAppCrashed
+  expr: sum(cf_application_instances_running{state=~"STARTED", organization_id="4175a5b2-78a4-42b0-94c2-280f8be41e7f"}) by(environment, deployment, organization_name, space_name, application_name) == 0
+  for: <%= p('cloudfoundry_alerts.app_crashed.evaluation_time') %>
+  labels:
+    service: <%= p('cloudfoundry_alerts.app_service_name') %>
+    severity: critical
+  annotations:
+    summary: "CF Application `{{$labels.environment}}/{{$labels.deployment}}/{{$labels.organization_name}}/{{$labels.space_name}}/{{$labels.application_name}}` does not have any instance running"
+    description: "CF Application `{{$labels.application_name}}` at environment `{{$labels.environment}}`, deployment `{{$labels.deployment}}`, org `{{$labels.organization_name}}`, and space `{{$labels.space_name}}` has not had any instance running during the last <%= p('cloudfoundry_alerts.app_crashed.evaluation_time') %>"


### PR DESCRIPTION
Add a dedicated `CFOperatorApp*` ruleset which allows us to focus only on apps running under the `cloud-gov` organization. The GUID isn't going to change, so hardcoding it is fine for now. I'd like to fix that at some point, but it's more work than I felt like doing now.

I haven't figured out a way to remove the other rule since it's hardcoded into the release with a wildcard, but this is a good start.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>