### PR TITLE
need aboslute paths for binaries

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -39,8 +39,8 @@ instance_groups:
               OUTDIR=/usr/local/share/ca-certificates/postfix
               mkdir -p ${OUTDIR}
               echo "((smtp-certificate))" > ${OUTDIR}/server.crt
-              update-ca-certificates
-              monit restart alertmanager
+              /usr/sbin/update-ca-certificates
+              /var/vcap/bosh/bin/monit restart alertmanager
           minute: '*/30'
           hour: '*'
           day: '*'


### PR DESCRIPTION
This should fix the issue we currently run into where after some uptime (days, I think) alertmanager stops being able to send emails because it somehow forgets about Postfix's certificate.
## Changes proposed in this pull request:
- provide absolute paths to binaries so cron can find them

## security considerations
None